### PR TITLE
Add August PCR500 Air Mouse and Keyboard

### DIFF
--- a/51-these-are-not-joysticks-rm.rules
+++ b/51-these-are-not-joysticks-rm.rules
@@ -105,3 +105,5 @@ SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="001f", ENV{ID_IN
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="001f", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="0028", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="0028", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="1d57", ATTRS{idProduct}=="ad03", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="1d57", ATTRS{idProduct}=="ad03", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""

--- a/51-these-are-not-joysticks.rules
+++ b/51-these-are-not-joysticks.rules
@@ -105,3 +105,5 @@ SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="001f", ENV{ID_IN
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="001f", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="0028", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="0028", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="1d57", ATTRS{idProduct}=="ad03", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="1d57", ATTRS{idProduct}=="ad03", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""

--- a/after_kernel_4_9/51-these-are-not-joysticks-rm.rules
+++ b/after_kernel_4_9/51-these-are-not-joysticks-rm.rules
@@ -81,3 +81,5 @@ SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="001f", ENV{ID_IN
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="001f", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="0028", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="0028", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="1d57", ATTRS{idProduct}=="ad03", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="1d57", ATTRS{idProduct}=="ad03", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""

--- a/after_kernel_4_9/51-these-are-not-joysticks.rules
+++ b/after_kernel_4_9/51-these-are-not-joysticks.rules
@@ -81,3 +81,5 @@ SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="001f", ENV{ID_IN
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="001f", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="0028", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="2516", ATTRS{idProduct}=="0028", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="1d57", ATTRS{idProduct}=="ad03", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="1d57", ATTRS{idProduct}=="ad03", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""

--- a/generate_rules.py
+++ b/generate_rules.py
@@ -99,6 +99,8 @@ DEVICES = [
 
     ('2516', '001f'),  # Cooler Master Storm Mizar Mouse
     ('2516', '0028'),  # Cooler Master Storm Alcor Mouse
+
+    ('1d57', 'ad03'),  # August PCR500 Air Mouse and Keyboard (Xenta, Freeway Technology)
 ]
 
 


### PR DESCRIPTION
The "August PCR500 Air Mouse and Keyboard" (a RF remote control with USB dongle) did not work properly with LibreELEC 8.2.5 running on a Raspberry Pi 3. The air mouse worked as expected but Kodi didn't respond to a keystroke.

idVendor=1d57
idProduct=ad03

output of dmesg:
```
[  467.650988] usb 1-1.2: new full-speed USB device number 5 using dwc_otg
[  467.770529] usb 1-1.2: New USB device found, idVendor=1d57, idProduct=ad03
[  467.770543] usb 1-1.2: New USB device strings: Mfr=1, Product=0, SerialNumber=0
[  467.770551] usb 1-1.2: Manufacturer: FREEWAY TECHNOLOGY
[  467.800392] input: FREEWAY TECHNOLOGY as /devices/platform/soc/3f980000.usb/usb1/1-1/1-1.2/1-1.2:1.2/0003:1D57:AD03.0003/input/input2
[  467.859968] hid-generic 0003:1D57:AD03.0003: input,hiddev0,hidraw0: USB HID v1.01 Keyboard [FREEWAY TECHNOLOGY] on usb-3f980000.usb-1.2/input2
[  467.865535] input: FREEWAY TECHNOLOGY as /devices/platform/soc/3f980000.usb/usb1/1-1/1-1.2/1-1.2:1.3/0003:1D57:AD03.0004/input/input3
[  467.866204] hid-generic 0003:1D57:AD03.0004: input,hidraw1: USB HID v1.01 Mouse [FREEWAY TECHNOLOGY] on usb-3f980000.usb-1.2/input3
```

output of lsusb: 
```
Bus 001 Device 005: ID 1d57:ad03 Xenta
```