### PR TITLE
Add Corsair Gaming M65 Pro RGB Mouse and K95 RGB PLATINUM Keyboard

### DIFF
--- a/generate_rules.py
+++ b/generate_rules.py
@@ -90,6 +90,8 @@ DEVICES = [
     ('09da', 'f624'),  # A4 Tech Co., Ltd Bloody B120 Keyboard
 
     ('1b1c', '1b3c'),  # Corsair Harpoon RGB gaming mouse
+    ('1b1c', '1b2e'),  # Corsair Gaming M65 Pro RGB Mouse
+    ('1b1c', '1b2d'),  # Corsair Gaming K95 RGB PLATINUM Keyboard
 
     ('1d57', 'ad03'),  # [T3] 2.4GHz and IR Air Mouse Remote Control
 


### PR DESCRIPTION
Add entry to blacklist:
('1b1c', '1b2e'),  # Corsair Gaming M65 Pro RGB Mouse
('1c1b', '2d1b'),  # Corsair Gaming K95 RGB PLATINUM Keyboard

Steam is detecting these devices as joysticks and causing games to crash at launch.