### PR TITLE
Add support for the ZSA Moonlander (3297:1969)

### DIFF
--- a/51-these-are-not-joysticks-rm.rules
+++ b/51-these-are-not-joysticks-rm.rules
@@ -447,3 +447,5 @@ SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0109", ENV{ID_IN
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0109", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0950", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0950", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="3297", ATTRS{idProduct}=="1969", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="3297", ATTRS{idProduct}=="1969", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""

--- a/51-these-are-not-joysticks.rules
+++ b/51-these-are-not-joysticks.rules
@@ -447,3 +447,5 @@ SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0109", ENV{ID_IN
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0109", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0950", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0950", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="3297", ATTRS{idProduct}=="1969", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="3297", ATTRS{idProduct}=="1969", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""

--- a/after_kernel_4_9/51-these-are-not-joysticks-rm.rules
+++ b/after_kernel_4_9/51-these-are-not-joysticks-rm.rules
@@ -423,3 +423,5 @@ SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0109", ENV{ID_IN
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0109", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0950", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0950", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="3297", ATTRS{idProduct}=="1969", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="3297", ATTRS{idProduct}=="1969", KERNEL=="js[0-9]*", RUN+="/bin/rm %E{DEVNAME}", ENV{ID_INPUT_JOYSTICK}=""

--- a/after_kernel_4_9/51-these-are-not-joysticks.rules
+++ b/after_kernel_4_9/51-these-are-not-joysticks.rules
@@ -423,3 +423,5 @@ SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0109", ENV{ID_IN
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0109", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0950", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
 SUBSYSTEM=="input", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0950", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="3297", ATTRS{idProduct}=="1969", ENV{ID_INPUT_JOYSTICK}=="?*", ENV{ID_INPUT_JOYSTICK}=""
+SUBSYSTEM=="input", ATTRS{idVendor}=="3297", ATTRS{idProduct}=="1969", KERNEL=="js[0-9]*", MODE="0000", ENV{ID_INPUT_JOYSTICK}=""

--- a/generate_rules.py
+++ b/generate_rules.py
@@ -283,6 +283,8 @@ DEVICES = [
 
     ('3434', '0109'),  # Keychron Q1
     ('3434', '0950'),  # Keychron V5 Max System Control
+
+    ('3297', '1969'),  # ZSA Moonlander
 ]
 
 


### PR DESCRIPTION
www.zsa.io/moonlander
```
$ lsusb | grep ZSA
Bus 003 Device 003: ID 3297:1969 ZSA Technology Labs Moonlander Mark I
```